### PR TITLE
Improve encoding performance

### DIFF
--- a/lib/exoml/encoder.ex
+++ b/lib/exoml/encoder.ex
@@ -5,41 +5,45 @@ defmodule Exoml.Encoder do
   end
 
   defp encode(bin, acc) when is_binary(bin) do
-    bin <> acc
+    acc <> bin
   end
 
   defp encode([node | tl], acc) do
-    encode(node, encode(tl, acc))
+    encode(tl, encode(node, acc))
   end
 
   defp encode([], acc), do: acc
 
   defp encode({:prolog, attrs, nil}, acc) do
-    "<?xml " <> encode_attrs(attrs) <> " ?>" <> acc
+    acc <> "<?xml " <> encode_attrs(attrs) <> " ?>"
   end
 
   defp encode({:doctype, attrs, nil}, acc) do
-    "<!DOCTYPE" <> encode_attrs(attrs) <> " !>" <> acc
+    acc <> "<!DOCTYPE" <> encode_attrs(attrs) <> " !>"
   end
 
   defp encode({tag, [], nil}, acc) do
-    "<#{tag}/>" <> acc
+    acc <> "<#{tag}/>"
   end
 
   defp encode({tag, attrs, nil}, acc) do
-    "<#{tag} #{encode_attrs(attrs)} />" <> acc
+    acc <> "<#{tag} #{encode_attrs(attrs)} />"
   end
 
   defp encode({tag, [], children}, acc) do
-    "<#{tag}>" <> encode(children, "") <> "</#{tag}>" <> acc
+    acc <> "<#{tag}>" <> encode(children, "") <> "</#{tag}>"
   end
 
   defp encode({tag, attrs, children}, acc) do
-    "<" <> tag <> " " <> encode_attrs(attrs) <> ">" <> encode(children, "") <> "</#{tag}>" <> acc
+    acc <> "<" <> tag <> " " <> encode_attrs(attrs) <> ">" <> encode(children, "") <> "</#{tag}>"
   end
 
   defp encode_attrs(attrs) do
     encode_attrs(attrs, "")
+  end
+
+  defp encode_attrs([attr | tl], "") do
+    encode_attr(attr) <> encode_attrs(tl)
   end
 
   defp encode_attrs([attr | tl], acc) do

--- a/lib/exoml/encoder.ex
+++ b/lib/exoml/encoder.ex
@@ -42,10 +42,6 @@ defmodule Exoml.Encoder do
     encode_attrs(attrs, "")
   end
 
-  defp encode_attrs([attr | tl], "") do
-    encode_attr(attr) <> encode_attrs(tl)
-  end
-
   defp encode_attrs([attr | tl], acc) do
     trail = encode_attr(attr)
     if acc == "" do


### PR DESCRIPTION
When working with a big XML file (13MB output, 10,000s of elements) we found it took 40s to encode it only. We found a way to optimize binary concatenation:

https://stackoverflow.com/questions/46095870/whats-the-best-way-to-build-long-strings-in-elixir

With the changes below the XML file encodes in 1.5s on our machines. Would you consider merging our changes back into your project?

Thank you